### PR TITLE
Make Month immutable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4.0
   - ruby-head
-  - jruby-19mode
+  - jruby
+  - jruby-head
+before_install:
+  - gem install bundler
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-19mode
+    - rvm: jruby-head

--- a/lib/month.rb
+++ b/lib/month.rb
@@ -22,6 +22,8 @@ class Month
     end
 
     @year, @number = year, number
+
+    freeze
   end
 
   attr_reader :year, :number

--- a/spec/month_spec.rb
+++ b/spec/month_spec.rb
@@ -77,6 +77,36 @@ describe 'Month' do
     range.map(&:number).must_equal([1, 2, 3, 4])
   end
 
+  it 'does not provide a year= setter' do
+    proc { Month.new(2016, 12).year = 2015 }.must_raise
+  end
+
+  it 'does not provide a number= setter' do
+    proc { Month.new(2016, 12).number = 11 }.must_raise
+  end
+
+  it 'forbids mutating year with #instance_variable_set' do
+    proc { Month.new(2016, 12).instance_variable_set('@year', 2015) }.must_raise
+  end
+
+  it 'forbids mutating month with #instance_variable_set' do
+    proc { Month.new(2016, 12).instance_variable_set('@month', 11) }.must_raise
+  end
+
+  class SubclassWithSetters < Month
+    attr_writer :year, :number
+  end
+
+  describe 'subclass with setters' do
+    it 'cannot mutate the year' do
+      proc { SubclassWithSetters.new(2016, 12).year = 2015 }.must_raise
+    end
+
+    it 'cannot mutate the number' do
+      proc { SubclassWithSetters.new(2016, 12).number = 11 }.must_raise
+    end
+  end
+
   describe 'next method' do
     it 'returns a month object denoting the next month' do
       Month.new(2014, 1).next.must_equal(Month.new(2014, 2))


### PR DESCRIPTION
Month is already operating as a value object, with its operations returning new Month instances rather than mutating the object. Having immutable Months is a helpful guarantee.

I imagine this change would bring Month to 2.0 as it could affect someone subclassing it. (Or using `#instance_variable_set`!)